### PR TITLE
Support Joomla! 4 using the Framework database package

### DIFF
--- a/src/Controllers/SubmitControllerCreate.php
+++ b/src/Controllers/SubmitControllerCreate.php
@@ -41,6 +41,7 @@ class SubmitControllerCreate extends AbstractController
 	private $databaseTypes = [
 		'mysql',
 		'mysqli',
+		'pgsql',
 		'pdomysql',
 		'postgresql',
 		'sqlazure',
@@ -119,6 +120,16 @@ class SubmitControllerCreate extends AbstractController
 			$this->getApplication()->setBody(json_encode($response));
 
 			return true;
+		}
+
+		// Account for configuration differences with 4.0
+		if (version_compare($data['cms_version'], '4.0', 'ge'))
+		{
+			// For 4.0 and later, we map `mysql` to the `pdomysql` option to correctly track the database type
+			if ($data['db_type'] === 'mysql')
+			{
+				$data['db_type'] = 'pdomysql';
+			}
 		}
 
 		$this->model->save((object) $data);

--- a/tests/Controllers/SubmitControllerCreateTest.php
+++ b/tests/Controllers/SubmitControllerCreateTest.php
@@ -79,6 +79,48 @@ class SubmitControllerCreateTest extends TestCase
 	}
 
 	/**
+	 * @testdox The controller is executed correctly for a Joomla! 4.0 installation running PDO MySQL
+	 *
+	 * @covers  Joomla\StatsServer\Controllers\SubmitControllerCreate::execute
+	 * @covers  Joomla\StatsServer\Controllers\SubmitControllerCreate::checkCMSVersion
+	 * @covers  Joomla\StatsServer\Controllers\SubmitControllerCreate::checkDatabaseType
+	 * @covers  Joomla\StatsServer\Controllers\SubmitControllerCreate::checkPHPVersion
+	 * @covers  Joomla\StatsServer\Controllers\SubmitControllerCreate::validateVersionNumber
+	 */
+	public function testTheControllerIsExecutedCorrectlyForAJoomla4InstallationRunningPdoMysql()
+	{
+		$mockModel = $this->getMockBuilder(StatsModel::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mockModel->expects($this->once())
+			->method('save');
+
+		$mockApp = $this->getMockBuilder(WebApplication::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mockInput = $this->getMockBuilder(Input::class)
+			->disableOriginalConstructor()
+			->setMethods(['getRaw', 'getString'])
+			->getMock();
+
+		$mockInput->expects($this->exactly(3))
+			->method('getRaw')
+			->willReturnOnConsecutiveCalls(PHP_VERSION, '5.6.23', '4.0.0');
+
+		$mockInput->expects($this->exactly(3))
+			->method('getString')
+			->willReturnOnConsecutiveCalls('1a2b3c4d', 'mysql', 'Darwin 14.1.0');
+
+		$controller = (new SubmitControllerCreate($mockModel))
+			->setApplication($mockApp)
+			->setInput($mockInput);
+
+		$this->assertTrue($controller->execute());
+	}
+
+	/**
 	 * @testdox The controller does not allow a record with no CMS version to be saved
 	 *
 	 * @covers  Joomla\StatsServer\Controllers\SubmitControllerCreate::execute


### PR DESCRIPTION
#### Summary of Changes

https://github.com/joomla/joomla-cms/pull/16402 implements the Framework's database package in the CMS, this updates the controller receiving data to handle the configuration updates needed for that PR.

#### Testing Instructions

When submitting data against the server from a 4.0 installation, when `mysql` is set as your database driver the entry will be tracked as `pdomysql`.