### PR TITLE
InstallCommand - ERROR: Call to undefined method InstallCommand::out()

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -166,7 +166,7 @@ class InstallCommand extends AbstractController implements CommandInterface
 			throw new \UnexpectedValueException('SQL file corrupted.');
 		}
 
-		$this->out(sprintf('Creating tables from file %s', realpath($fName)), false);
+		$this->getApplication()->out(sprintf('Creating tables from file %s', realpath($fName)), false);
 
 		foreach ($this->db->splitSql($sql) as $query)
 		{


### PR DESCRIPTION
Pull Request for Issue
ERROR: Call to undefined method Joomla\StatsServer\Commands\InstallCommand::out()


#### Summary of Changes
fix 

#### Testing Instructions
try to run `bin/stats install`