### PR TITLE
[RFC] API endpoint for combined Joomla & PHP version #37

### DIFF
--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -59,6 +59,13 @@ CREATE TABLE IF NOT EXISTS `#__jstats_counter_server_os` (
   KEY `idx_version_count` (`server_os`, `count`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS `#__jstats_counter_cms_php_version` (
+  `cms_version` varchar(15) NOT NULL,
+  `php_version` varchar(15) NOT NULL,
+  `count` INT NOT NULL,
+  PRIMARY KEY (`cms_version`,`php_version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
+
 DELIMITER $$
 
 CREATE
@@ -130,6 +137,20 @@ TRIGGER `stat_insert`
       UPDATE `#__jstats_counter_server_os`
       SET count = count + 1
       WHERE `server_os` = NEW.server_os;
+    END IF;
+
+	IF NOT EXISTS (SELECT 1
+      FROM `#__jstats_counter_cms_php_version` AS counter
+      WHERE NEW.php_version = counter.php_version
+        and NEW.cms_version = counter.cms_version
+    )
+    THEN
+      INSERT INTO `#_jstats_counter_cms_php_version` (cms_version, php_version, count) VALUES (NEW.cms_version, NEW.php_version, 1);
+    ELSE
+      UPDATE `#__jstats_counter_cms_php_version`
+      SET count = count + 1
+      WHERE `php_version` = NEW.php_version
+	  AND cms_version = NEW.cms_version
     END IF;
   END$$
 

--- a/etc/newtable_1st_population.sql
+++ b/etc/newtable_1st_population.sql
@@ -1,0 +1,4 @@
+INSERT INTO `#__jstats_counter_cms_php_version`
+SELECT  cms_version, php_version , COUNT(*) as count
+FROM #__jstats 
+GROUP BY cms_version, php_version;

--- a/src/Models/StatsModel.php
+++ b/src/Models/StatsModel.php
@@ -46,6 +46,16 @@ class StatsModel implements DatabaseModelInterface
 		$query      = $db->getQuery(true);
 		$columnList = $db->getTableColumns('#__jstats');
 
+		// The new endPoint
+		if ($column === 'cms_php')
+		{
+			return $db->setQuery(
+				$query
+					->select('*')
+					->from($db->quoteName('#__jstats_counter_cms_php_version'))
+			)->loadAssocList();
+		}
+
 		// Validate the requested column is actually in the table
 		if ($column !== '')
 		{

--- a/src/Views/Stats/StatsJsonView.php
+++ b/src/Views/Stats/StatsJsonView.php
@@ -106,6 +106,12 @@ class StatsJsonView extends BaseJsonView
 
 		if ($this->source)
 		{
+			// The new combined API endPoint
+			if ($this->source === 'cms_php')
+			{
+				return $this->processCombined($items);
+			}
+
 			return $this->processSingleSource($items);
 		}
 
@@ -332,5 +338,35 @@ class StatsJsonView extends BaseJsonView
 		}
 
 		return $responseData;
+	}
+/**
+	 * Process the response for a combined data source.
+	 *
+	 * @param   array  $items  The source items to process.
+	 *
+	 * @return  string  The rendered view.
+	 */
+	private function processCombined(array $items) : string
+	{
+		$data = [
+			${$this->source} = [],
+		];
+
+		$this->totalItems = 0;
+
+		foreach ($items as $item)
+		{
+			$data[$this->source][$item['cms_version'] . ':' . $item['php_version']]= $item['count'];
+			$this->totalItems += $item['count'];
+		}
+
+
+		$responseData = $this->buildResponseData($data);
+
+		$responseData['total'] = $this->totalItems;
+
+		$this->addData('data', $responseData);
+
+		return parent::render();
 	}
 }

--- a/src/Views/Stats/StatsJsonView.php
+++ b/src/Views/Stats/StatsJsonView.php
@@ -237,8 +237,6 @@ class StatsJsonView extends BaseJsonView
 			$this->totalItems += $item['count'];
 		}
 
-		unset($generator);
-
 		$responseData = $this->buildResponseData($data);
 
 		$responseData['total'] = $this->totalItems;
@@ -339,8 +337,8 @@ class StatsJsonView extends BaseJsonView
 
 		return $responseData;
 	}
-/**
-	 * Process the response for a combined data source.
+	/**
+	 * Process the response for a combined cms_php data source.
 	 *
 	 * @param   array  $items  The source items to process.
 	 *
@@ -348,24 +346,19 @@ class StatsJsonView extends BaseJsonView
 	 */
 	private function processCombined(array $items) : string
 	{
-		$data = [
-			${$this->source} = [],
-		];
+		$data = [];
 
 		$this->totalItems = 0;
 
 		foreach ($items as $item)
 		{
-			$data[$this->source][$item['cms_version'] . ':' . $item['php_version']]= $item['count'];
+			$data[$this->source][$item['cms_version']][$item['php_version']]= $item['count'];
 			$this->totalItems += $item['count'];
 		}
 
+		$data['total'] = $this->totalItems;
 
-		$responseData = $this->buildResponseData($data);
-
-		$responseData['total'] = $this->totalItems;
-
-		$this->addData('data', $responseData);
+		$this->addData('data', $data);
 
 		return parent::render();
 	}


### PR DESCRIPTION
Pull Request for Issue #37 .

#### Summary of Changes

-  create a new table
-  populate the new table with current data
-  implement the insert trigger
-  implement the update trigger
-  expose the new api endpoint

to do 
-  mod_joomladata ??


#### Testing Instructions
apply this patch
from the mysql console
drop the current insert trigger
drop the current update trigger
create the new insert trigger
create the new update trigger
call the new api endopoint `http://localhost/jstats/www/?source=cms_php`

this is how the new API endpoint response look like

![screenshot from 2018-09-05 20-09-38](https://user-images.githubusercontent.com/181681/45112406-c7579400-b147-11e8-9736-ee7fce36d068.png)


#### Additional comments
if this will be accepted documentation https://developer.joomla.org/about/stats/api.html should be updated
i was not able to run the `bin/stats install `  for the trigger sections  :baby: 
i've switched to the mysql console where it works successfully
