### PR TITLE
add  2 new endpoint to the api

### DIFF
--- a/etc/migrations/20200313001.sql
+++ b/etc/migrations/20200313001.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `#__jstats_counter_cms_php_version` (
+  `cms_version` varchar(15) NOT NULL,
+  `php_version` varchar(15) NOT NULL,
+  `count` INT NOT NULL,
+  PRIMARY KEY (`cms_version`,`php_version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `#__jstats_counter_db_type_version` (
+  `db_type` varchar(15) NOT NULL,
+  `db_version` varchar(15) NOT NULL,
+  `count` INT NOT NULL,
+  PRIMARY KEY (`db_type`,`db_version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;

--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -59,6 +59,20 @@ CREATE TABLE IF NOT EXISTS `#__jstats_counter_server_os` (
   KEY `idx_version_count` (`server_os`, `count`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS `#__jstats_counter_cms_php_version` (
+  `cms_version` varchar(15) NOT NULL,
+  `php_version` varchar(15) NOT NULL,
+  `count` INT NOT NULL,
+  PRIMARY KEY (`cms_version`,`php_version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `#__jstats_counter_db_type_version` (
+  `db_type` varchar(15) NOT NULL,
+  `db_version` varchar(15) NOT NULL,
+  `count` INT NOT NULL,
+  PRIMARY KEY (`db_type`,`db_version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
+
 DELIMITER $$
 
 CREATE
@@ -130,6 +144,34 @@ TRIGGER `stat_insert`
       UPDATE `#__jstats_counter_server_os`
       SET count = count + 1
       WHERE `server_os` = NEW.server_os;
+    END IF;
+ 
+    IF (SELECT count(*)
+      FROM `#__jstats_counter_cms_php_version` AS counter
+      WHERE NEW.php_version = counter.php_version
+        and NEW.cms_version = counter.cms_version
+    ) = 0
+    THEN
+      INSERT INTO `#__jstats_counter_cms_php_version` (cms_version, php_version, count) VALUES (NEW.cms_version, NEW.php_version, 1);
+    ELSE
+      UPDATE `#__jstats_counter_cms_php_version`
+      SET `count` = `count` + 1
+      WHERE `php_version` = NEW.php_version
+	  AND `cms_version` = NEW.cms_version;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1
+      FROM `#__jstats_counter_db_type_version` AS counter
+      WHERE NEW.db_type = counter.db_type
+        and NEW.db_version = counter.db_version
+    )
+    THEN
+      INSERT INTO `#__jstats_counter_db_type_version` (db_type, db_version, count) VALUES (NEW.db_type, NEW.db_version, 1);
+    ELSE
+      UPDATE `#__jstats_counter_db_type_version`
+      SET count = count + 1
+      WHERE `db_type` = NEW.db_type
+	  AND db_version = NEW.db_version;
     END IF;
   END$$
 
@@ -233,6 +275,52 @@ TRIGGER `stat_update`
         WHERE `server_os` = NEW.server_os;
       END IF;
     END IF;
+ 
+    IF (OLD.php_version <> NEW.php_version AND OLD.cms_version <> NEW.cms_version) OR
+    (OLD.php_version = NEW.php_version AND OLD.cms_version <> NEW.cms_version) OR
+    (OLD.php_version <> NEW.php_version AND OLD.cms_version = NEW.cms_version)
+    THEN
+      UPDATE `#__jstats_counter_cms_php_version`
+      SET count = count - 1
+      WHERE `php_version` = OLD.php_version
+        AND `cms_version` = OLD.cms_version;
+
+      IF NOT EXISTS (SELECT 1
+        FROM `#__jstats_counter_cms_php_version` AS counter
+        WHERE NEW.php_version = counter.php_version
+          AND NEW.cms_version = counter.cms_version
+      )
+      THEN
+       INSERT INTO `#__jstats_counter_cms_php_version` (cms_version, php_version, count) VALUES (NEW.cms_version, NEW.php_version, 1);
+      ELSE
+       UPDATE `#__jstats_counter_cms_php_version`
+       SET count = count + 1
+       WHERE `php_version` = NEW.php_version
+	       AND `cms_version` = NEW.cms_version;
+      END IF;
+   END IF;
+
+   IF NOT (OLD.db_type = NEW.db_type AND OLD.db_version = NEW.db_version)
+    THEN
+      UPDATE `#__jstats_counter_db_type_version`
+      SET count = count - 1
+      WHERE `db_type` = OLD.db_type
+        AND `db_version` = OLD.db_version;
+      IF NOT EXISTS (SELECT 1
+        FROM `#__jstats_counter_db_type_version` AS counter
+        WHERE NEW.db_type = counter.db_type
+          AND NEW.db_version = counter.db_version
+      )
+      THEN
+       INSERT INTO `#__jstats_counter_db_type_version` (db_type, db_version, count) VALUES (NEW.db_type, NEW.db_version, 1);
+      ELSE
+       UPDATE `#__jstats_counter_db_type_version`
+       SET count = count + 1
+       WHERE `db_type` = NEW.db_type
+	       AND `db_version` = NEW.db_version;
+      END IF;
+  END IF;
+ 
   END$$
 
 DELIMITER ;

--- a/etc/mysql.sql
+++ b/etc/mysql.sql
@@ -22,7 +22,8 @@ CREATE TABLE `#__migrations` (
 
 INSERT INTO `#__migrations` (`version`) VALUES
 ('20160618001'),
-('20180413001');
+('20180413001'),
+('20200313001');
 
 CREATE TABLE IF NOT EXISTS `#__jstats_counter_php_version` (
   `php_version` varchar(15) NOT NULL,

--- a/etc/unatantum.sql
+++ b/etc/unatantum.sql
@@ -25,10 +25,10 @@ GROUP BY cms_version;
 
 INSERT INTO `#__jstats_counter_cms_php_version`
 SELECT  cms_version, php_version , COUNT(*) as count
-FROM jstats 
+FROM `#__jstats`
 GROUP BY cms_version, php_version;
 
 INSERT INTO `#__jstats_counter_db_type_version`
 SELECT  db_type, db_version , COUNT(*) as count
-FROM jstats 
+FROM `#__jstats`
 GROUP BY db_type, db_version;

--- a/etc/unatantum.sql
+++ b/etc/unatantum.sql
@@ -22,3 +22,13 @@ INSERT INTO `#__jstats_counter_cms_version`
 SELECT  cms_version , COUNT(*) as count
 FROM `#__jstats`
 GROUP BY cms_version;
+
+INSERT INTO `#__jstats_counter_cms_php_version`
+SELECT  cms_version, php_version , COUNT(*) as count
+FROM jstats 
+GROUP BY cms_version, php_version;
+
+INSERT INTO `#__jstats_counter_db_type_version`
+SELECT  db_type, db_version , COUNT(*) as count
+FROM jstats 
+GROUP BY db_type, db_version;

--- a/src/Repositories/StatisticsRepository.php
+++ b/src/Repositories/StatisticsRepository.php
@@ -95,14 +95,44 @@ class StatisticsRepository
 
 		foreach (self::ALLOWED_SOURCES as $column)
 		{
-			$return[$column] = $this->db->setQuery(
-				$this->db->getQuery(true)
-					->select($column)
-					->select('COUNT(' . $column . ') AS count')
-					->from($this->db->quoteName('#__jstats'))
-					->where('modified BETWEEN DATE_SUB(NOW(), INTERVAL 90 DAY) AND NOW()')
-					->group($column)
-			)->loadAssocList();
+			if (($column !== 'cms_php_version') && ($column !== 'db_type_version'))
+			{
+				$return[$column] = $this->db->setQuery(
+					$this->db->getQuery(true)
+						->select($column)
+						->select('COUNT(' . $column . ') AS count')
+						->from($this->db->quoteName('#__jstats'))
+						->where('modified BETWEEN DATE_SUB(NOW(), INTERVAL 90 DAY) AND NOW()')
+						->group($column)
+				)->loadAssocList();
+				continue;
+			}
+
+			if ($column === 'cms_php_version')
+			{
+				$return['cms_php_version'] = $this->db->setQuery(
+					$this->db->getQuery(true)
+						->select('CONCAT(' . $this->db->quoteName('cms_version') . ', ' . $this->db->quote(' - ') . ', ' . $this->db->quoteName('php_version') . ') AS cms_php_version')
+						->select('COUNT(*) AS count')
+						->from($this->db->quoteName('#__jstats'))
+						->where('modified BETWEEN DATE_SUB(NOW(), INTERVAL 90 DAY) AND NOW()')
+						->group('CONCAT(' . $this->db->quoteName('cms_version') . ', ' . $this->db->quote(' - ') . ', ' . $this->db->quoteName('php_version') . ')')
+				)->loadAssocList();
+				continue;
+			}
+
+			if ($column === 'db_type_version')
+			{
+				$return['db_type_version'] = $this->db->setQuery(
+					$this->db->getQuery(true)
+						->select('CONCAT(' . $this->db->quoteName('db_type') . ', ' . $this->db->quote(' - ') . ', ' . $this->db->quoteName('db_version') . ') AS db_type_version')
+						->select('COUNT(*) AS count')
+						->from($this->db->quoteName('#__jstats'))
+						->where('modified BETWEEN DATE_SUB(NOW(), INTERVAL 90 DAY) AND NOW()')
+						->group('CONCAT(' . $this->db->quoteName('db_type') . ', ' . $this->db->quote(' - ') . ', ' . $this->db->quoteName('db_version') . ')')
+				)->loadAssocList();
+				continue;
+			}
 		}
 
 		return $return;

--- a/src/Repositories/StatisticsRepository.php
+++ b/src/Repositories/StatisticsRepository.php
@@ -21,7 +21,7 @@ class StatisticsRepository
 	 *
 	 * @var  string[]
 	 */
-	public const ALLOWED_SOURCES = ['php_version', 'db_type', 'db_version', 'cms_version', 'server_os'];
+	public const ALLOWED_SOURCES = ['php_version', 'db_type', 'db_version', 'cms_version', 'server_os', 'cms_php_version', 'db_type_version'];
 
 	/**
 	 * The database driver.

--- a/src/Views/Stats/StatsJsonView.php
+++ b/src/Views/Stats/StatsJsonView.php
@@ -9,12 +9,12 @@
 namespace Joomla\StatsServer\Views\Stats;
 
 use Joomla\StatsServer\Repositories\StatisticsRepository;
-use Joomla\View\BaseJsonView;
+use Joomla\View\JsonView;
 
 /**
  * JSON response for requesting the stats data.
  */
-class StatsJsonView extends BaseJsonView
+class StatsJsonView extends JsonView
 {
 	/**
 	 * Flag if the response should return the raw data.
@@ -140,8 +140,12 @@ class StatsJsonView extends BaseJsonView
 								{
 									$item[$source] = 'unknown';
 								}
+
 								${$source}[$item[$source]] = $item['count'];
+
+								$this->totalItems += $item['count'];
 							}
+
 							break;
 
 						case 'cms_php_version':
@@ -149,8 +153,10 @@ class StatsJsonView extends BaseJsonView
 							{
 								$index = $item['cms_version'] . ' - ' . $item['php_version'];
 								$cms_php_version[$index] = $item['count'];
-								$this->totalItems += $item['count'];								
+
+								$this->totalItems += $item['count'];
 							}
+
 							break;
 
 						case 'db_type_version':
@@ -158,15 +164,19 @@ class StatsJsonView extends BaseJsonView
 							{
 								$index = $item['db_type'] . ' - ' . $item['db_version'];
 								$db_type_version[$index] = $item['count'];
-								$this->totalItems += $item['count'];								
+
+								$this->totalItems += $item['count'];
 							}
+
 							break;
 
 						default:
 							if (isset($item[$source]) && $item[$source] !== null)
 							{
 								${$source}[$item[$source]] = $item['count'];
+								$this->totalItems += $item['count'];
 							}
+
 							break;
 					}
 				}

--- a/src/Views/Stats/StatsJsonView.php
+++ b/src/Views/Stats/StatsJsonView.php
@@ -28,7 +28,7 @@ class StatsJsonView extends BaseJsonView
 	 *
 	 * @var  array
 	 */
-	private $dataSources = ['php_version', 'db_type', 'db_version', 'cms_version', 'server_os'];
+	private $dataSources = ['php_version', 'db_type', 'db_version', 'cms_version', 'server_os', 'cms_php_version', 'db_type_version'];
 
 	/**
 	 * Flag if the response should return the recently updated data.
@@ -113,11 +113,13 @@ class StatsJsonView extends BaseJsonView
 			return $this->processSingleSource($items);
 		}
 
-		$php_version = [];
-		$db_type     = [];
-		$db_version  = [];
-		$cms_version = [];
-		$server_os   = [];
+		$php_version     = [];
+		$db_type         = [];
+		$db_version      = [];
+		$cms_version     = [];
+		$server_os       = [];
+		$cms_php_version = [];
+		$db_type_version = [];
 
 		// If we have the entire database, we have to loop within each group to put it all together
 		foreach ($items as $group)
@@ -128,28 +130,57 @@ class StatsJsonView extends BaseJsonView
 			{
 				foreach ($this->dataSources as $source)
 				{
-					if (isset($item[$source]) && $item[$source] !== null)
+					switch ($source)
 					{
-						// Special case, if the server is empty then change the key to "unknown"
-						if ($source === 'server_os' && empty($item[$source]))
-						{
-							$item[$source] = 'unknown';
-						}
+						case 'server_os':
+							if (isset($item[$source]) && $item[$source] !== null)
+							{
+								// Special case, if the server is empty then change the key to "unknown"
+								if (empty($item[$source]))
+								{
+									$item[$source] = 'unknown';
+								}
+								${$source}[$item[$source]] = $item['count'];
+							}
+							break;
 
-						${$source}[$item[$source]] = $item['count'];
+						case 'cms_php_version':
+							if ((isset($item['cms_version']) && $item['cms_version'] !== null) && (isset($item['php_version']) && $item['php_version'] !== null))
+							{
+								$index = $item['cms_version'] . ' - ' . $item['php_version'];
+								$cms_php_version[$index] = $item['count'];
+								$this->totalItems += $item['count'];								
+							}
+							break;
 
-						$this->totalItems += $item['count'];
+						case 'db_type_version':
+							if ((isset($item['db_type']) && $item['db_type'] !== null) && (isset($item['db_version']) && $item['db_version'] !== null))
+							{
+								$index = $item['db_type'] . ' - ' . $item['db_version'];
+								$db_type_version[$index] = $item['count'];
+								$this->totalItems += $item['count'];								
+							}
+							break;
+
+						default:
+							if (isset($item[$source]) && $item[$source] !== null)
+							{
+								${$source}[$item[$source]] = $item['count'];
+							}
+							break;
 					}
 				}
 			}
 		}
 
 		$data = [
-			'php_version' => $php_version,
-			'db_type'     => $db_type,
-			'db_version'  => $db_version,
-			'cms_version' => $cms_version,
-			'server_os'   => $server_os,
+			'php_version'     => $php_version,
+			'db_type'         => $db_type,
+			'db_version'      => $db_version,
+			'cms_version'     => $cms_version,
+			'server_os'       => $server_os,
+			'cms_php_version' => $cms_php_version,
+			'db_type_version' => $db_type_version,
 		];
 
 		$responseData = $this->buildResponseData($data);
@@ -225,17 +256,34 @@ class StatsJsonView extends BaseJsonView
 
 		foreach ($items as $item)
 		{
-			// Special case, if the server is empty then change the key to "unknown"
-			if ($this->source === 'server_os' && empty(trim($item[$this->source])))
+			switch ($this->source)
 			{
-				$item[$this->source] = 'unknown';
+				case 'server_os':
+					// Special case, if the server is empty then change the key to "unknown"
+					if (empty(trim($item[$this->source])))
+					{
+						$item[$this->source] = 'unknown';
+					}
+					$data[$this->source][$item[$this->source]] = $item['count'];
+					break;
+
+				case 'cms_php_version':
+					$index = $item['cms_version'] . ' - ' . $item['php_version'];
+					$data[$this->source][$index] = $item['count'];
+					break;
+
+				case 'db_type_version':
+					$index = $item['db_type'] . ' - ' . $item['db_version'];
+					$data[$this->source][$index] = $item['count'];
+					break;
+
+				default:
+					$data[$this->source][$item[$this->source]] = $item['count'];
+					break;
 			}
 
-			$data[$this->source][$item[$this->source]] = $item['count'];
 			$this->totalItems += $item['count'];
 		}
-
-		unset($generator);
 
 		$responseData = $this->buildResponseData($data);
 
@@ -320,6 +368,8 @@ class StatsJsonView extends BaseJsonView
 					break;
 
 				case 'db_type':
+				case 'cms_php_version':
+				case 'db_type_version':
 				default:
 					// For now, group by the object name and figure out the percentages
 					$sanitizedData = [];

--- a/tests/Database/MigrationsTest.php
+++ b/tests/Database/MigrationsTest.php
@@ -62,7 +62,7 @@ class MigrationsTest extends DatabaseTestCase
 
 		$this->assertTrue($status->tableExists);
 		$this->assertSame('20160618001', $status->currentVersion);
-		$this->assertSame(1, $status->missingMigrations);
+		$this->assertGreaterThanOrEqual(1, $status->missingMigrations);
 	}
 
 	/**


### PR DESCRIPTION
rework of  #40, #41 

#### Summary of Changes
added 2 new end-point

- cms_php_version
- db_type_version

added 2 new tables
updated triggers

#### Testing Instructions

- create the new 2 tables
- drop the 2 triggers and execute the new 2 trigger
- populate the new tables for the 1st time


### api endpoint 
`?source=cms_php_version`

![Screenshot from 2019-04-08 20-00-16](https://user-images.githubusercontent.com/181681/55746051-0846bc80-5a39-11e9-908d-80e6bbc09697.png)

### api endpoint 
`?source=db_type_version`

![Screenshot from 2019-04-08 20-02-16](https://user-images.githubusercontent.com/181681/55746137-447a1d00-5a39-11e9-8efb-c1899e18759b.png)



when authorized you should expect something like : 

![Screenshot from 2019-04-08 20-06-38](https://user-images.githubusercontent.com/181681/55746403-df72f700-5a39-11e9-9310-70ed3c1b4089.png)


